### PR TITLE
Sub-issue管理機能のドキュメント追加とGitHub CLI API権限設定

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,7 +14,10 @@
       "Bash(rustup --version)",
       "Bash(rustup show)",
       "Bash(rustup toolchain list)",
-      "Bash(rustup component list)"
+      "Bash(rustup component list)",
+      "Bash(gh api repos/{owner}/{repo}/issues*)",
+      "Bash(gh api repos/{owner}/{repo}/issues/*/sub_issues)",
+      "Bash(gh --version)"
     ]
   },
   "hooks": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,31 @@ The project uses mise.toml for development tool management with:
 - Use existing Issue format: 概要, 背景, 実装要件, 受け入れ条件, テスト要件
 - Include appropriate labels for categorization
 
+#### Sub-Issue Management
+GitHub's sub-issue feature allows breaking down large work into smaller, manageable tasks with hierarchical structure.
+
+**Sub-Issue API Operations via GitHub CLI:**
+```bash
+# List sub-issues for a parent issue
+gh api repos/{owner}/{repo}/issues/{issue_number}/sub_issues
+
+# Add existing issue as sub-issue
+gh api -X POST repos/{owner}/{repo}/issues/{issue_number}/sub_issues -f sub_issue_id={sub_issue_id}
+
+# Remove sub-issue from parent
+gh api -X DELETE repos/{owner}/{repo}/issues/{issue_number}/sub_issue -f sub_issue_id={sub_issue_id}
+
+# Reprioritize sub-issue position
+gh api -X PATCH repos/{owner}/{repo}/issues/{issue_number}/sub_issues/priority -f sub_issue_id={sub_issue_id} -f after_id={after_id}
+```
+
+**Sub-Issue Guidelines:**
+- Use sub-issues for complex features requiring multiple implementation steps
+- Maximum 100 sub-issues per parent issue, up to 8 levels of nesting
+- Sub-issues provide visual progress tracking with `sub_issues_summary` data
+- Cross-repository sub-issues are supported
+- Requires "triage" permissions for sub-issue operations
+
 ### Branch Naming Convention
 - Branch names MUST follow the pattern: `feature/[Issue番号]`
 - Examples: `feature/11`, `feature/23`


### PR DESCRIPTION
## 概要
- CLAUDE.mdにSub-Issue Management セクションを追加
- GitHub CLI API経由でのsub-issue操作コマンドを文書化
- .claude/settings.jsonにgh api権限を追加

## 変更内容

### CLAUDE.md
- Sub-Issue Management セクションの追加
- GitHub CLI API操作コマンドの文書化
- Sub-issueガイドラインの追加
- 制限事項と権限要件の記載

### .claude/settings.json
- `gh api repos/{owner}/{repo}/issues*` 権限追加
- `gh api repos/{owner}/{repo}/issues/*/sub_issues` 権限追加
- `gh --version` 権限追加

## テスト結果
- GitHub CLI API経由でのsub-issue操作を確認済み
- 既存のsub-issue（Issue #2 -> Issue #14）で動作確認済み

## チェックリスト
- [x] ドキュメントの追加
- [x] 権限設定の追加
- [x] API操作の動作確認