### PR TITLE
chore: tokio-console用のconsole-subscriberをfeature flagに切り出す

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ ratatui = "0.29.0"
 crossterm = { version = "0.29.0", features = ["event-stream"] }
 color-eyre = "0.6.3"
 futures = "0.3"
-console-subscriber = "0.4.1"
+console-subscriber = { version = "0.4.1", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rtnetlink = "0.17.0"
@@ -69,3 +69,6 @@ libc = "0.2.174"
 tempfile = "3.20.0"
 mockall = "0.13.1"
 tokio-test = "0.4.4"
+
+[features]
+tokio-console = ["dep:console-subscriber"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ mod tui;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    #[cfg(debug_assertions)]
+    #[cfg(all(debug_assertions, feature = "tokio-console"))]
     console_subscriber::init();
     color_eyre::install()?;
 


### PR DESCRIPTION
## 概要
tokio-console用のconsole-subscriberをfeature flagに切り出す

## 変更内容
- `console-subscriber`をfeature flagとして切り出し
- `tokio_unstable`フラグを`console-subscriber`機能使用時のみ有効化
- 通常のビルドでは`tokio_unstable`フラグなしでビルド可能

## 関連Issue
Closes #27

## テスト結果
- [x] `cargo build` - ビルド成功
- [x] `cargo test` - テスト通過
- [x] `cargo clippy` - Lintチェック通過
- [x] `cargo fmt` - フォーマットチェック通過

## チェックリスト

- [x] 適切なブランチ命名規則に従っている (`feature/27`)
- [x] コミットメッセージが適切である
- [x] 関連するドキュメントを更新している（必要に応じて）
- [x] テストコードを追加・更新している（必要に応じて）

## 破壊的変更
なし

## 追加情報
- 通常のビルド: `cargo build`
- console-subscriber有効化: `cargo build --features console-subscriber`
- tokio-console使用時: `RUSTFLAGS="--cfg tokio_unstable" cargo build --features console-subscriber`