### PR TITLE
perf ⚡: HashMapをFxHashMapに統一してパフォーマンス最適化

### DIFF
--- a/src/net_utils/netlink/macos.rs
+++ b/src/net_utils/netlink/macos.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
 use std::mem::MaybeUninit;
 use std::net::{IpAddr, Ipv4Addr};
 use std::{io, mem, process, slice};
 
+use fxhash::FxHashMap;
 use libc::{
     AF_INET, AF_LINK, PF_ROUTE, RTA_DST, RTA_GATEWAY, RTA_IFP, RTAX_DST, RTAX_GATEWAY, RTAX_IFP,
     RTAX_MAX, RTF_GATEWAY, RTF_HOST, RTF_STATIC, RTF_UP, RTM_GET, RTM_VERSION, SOCK_RAW, c_int,
@@ -93,7 +93,7 @@ impl Netlink {
 
     fn get_interfaces(&self) -> Result<Vec<NetworkInterfaceInner>, NetlinkError> {
         let ifaddrs = getifaddrs().map_err(NetlinkError::FailedToGetIfAddrs)?;
-        let mut interfaces: HashMap<String, NetworkInterfaceInner> = HashMap::new();
+        let mut interfaces: FxHashMap<String, NetworkInterfaceInner> = FxHashMap::default();
 
         for ifaddr in ifaddrs {
             let iface_name = ifaddr.interface_name.clone();

--- a/src/tui/models.rs
+++ b/src/tui/models.rs
@@ -1,9 +1,9 @@
-use std::collections::HashMap;
 use std::net::Ipv4Addr;
 use std::time::Instant;
 
 use chrono::Duration;
 use crossterm::event;
+use fxhash::FxHashMap;
 use ratatui::widgets::TableState;
 
 use crate::config::{Config, Target};
@@ -82,10 +82,10 @@ pub enum PingStatus {
 }
 
 pub struct AppState {
-    pub ping_results: HashMap<String, PingResult>,
+    pub ping_results: FxHashMap<String, PingResult>,
     pub targets: Vec<String>,
     pub selected_index: usize,
-    pub traceroute_results: HashMap<String, Vec<TracerouteHopHistory>>,
+    pub traceroute_results: FxHashMap<String, Vec<TracerouteHopHistory>>,
     pub show_details: bool,
     pub table_state: TableState,
     /// ConfigのTargetsへの参照（IDマッチング用）
@@ -94,7 +94,7 @@ pub struct AppState {
 
 impl AppState {
     pub fn new(targets: Vec<String>, config: &Config) -> Self {
-        let mut ping_results = HashMap::new();
+        let mut ping_results = FxHashMap::default();
 
         for target in &targets {
             ping_results.insert(
@@ -123,7 +123,7 @@ impl AppState {
             ping_results,
             targets,
             selected_index: 0,
-            traceroute_results: HashMap::new(),
+            traceroute_results: FxHashMap::default(),
             show_details: false,
             table_state,
             target_configs: config.targets.clone(),


### PR DESCRIPTION
## 概要
std::collections::HashMapをfxhash::FxHashMapに統一し、HashDoS保護のオーバーヘッドを除去してパフォーマンスを最適化

## 変更内容
- `src/tui/models.rs`: AppStateのping_results、traceroute_resultsをFxHashMapに変更
- `src/net_utils/netlink/macos.rs`: ネットワークインターフェースマップをFxHashMapに変更
- std::collections::HashMapのimportをfxhash::FxHashMapに置換
- HashMap::newの呼び出しをFxHashMap::defaultに変更

## 関連Issue
Closes #28

## テスト結果
- [x] `cargo build` - ビルド成功
- [x] `cargo test` - テスト通過 (41 passed; 0 failed; 1 ignored)
- [x] `cargo clippy` - Lintチェック通過
- [x] `cargo fmt` - フォーマットチェック通過

## チェックリスト

- [x] 適切なブランチ命名規則に従っている (`feature/28`)
- [x] コミットメッセージが適切である
- [x] 関連するドキュメントを更新している（必要に応じて）
- [x] テストコードを追加・更新している（既存テストで十分カバー）

## 破壊的変更
なし

## 追加情報
- fxhashクレートは既にCargo.tomlに含まれており、他の箇所で既に使用されている
- FxHashMapはHashDoS攻撃保護を持たないため、信頼できる入力に対してより高速
- メモリ使用量とハッシュ計算のパフォーマンスが向上