### PR TITLE
fix: TracerouteのID計算バグ修正と設定ファイル順序保持による表示改善 (fixes #26)

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use fxhash::FxHashMap;
-use itertools::Itertools;
 use log::info;
 use pcap_worker::{PingTarget, PingTargets};
 use tokio::sync::mpsc;
@@ -47,14 +46,14 @@ pub async fn run_ping_monitoring(
             host: target_ip,
         });
     }
-    info!(
-        "ping targets: [{}]",
-        ping_targets_by_ni
-            .values()
-            .flat_map(|t| t.targets.clone())
-            .map(|target| target.host.to_string())
-            .join(", ")
-    );
+
+    // 設定ファイルの順序を保持してターゲットを表示
+    let ordered_targets: Vec<String> = config
+        .targets
+        .iter()
+        .map(|target| target.host.clone())
+        .collect();
+    info!("ping targets: [{}]", ordered_targets.join(", "));
 
     // ARP Tableの初期化
     let arp_table = Arc::new(ArpTable::new(&config.arp));

--- a/src/core/worker_pool.rs
+++ b/src/core/worker_pool.rs
@@ -60,6 +60,9 @@ impl WorkerPool {
         // Traceroute Workerの集合
         let mut traceroute_workers = Vec::new();
 
+        // 全体のターゲット数を計算
+        let total_target_count = targets.values().map(|pt| pt.targets.len()).sum::<usize>() as u16;
+
         // 各インターフェースに対してPcap Workerを起動
         for ping_targets in targets.values() {
             let target_ips = ping_targets
@@ -79,7 +82,6 @@ impl WorkerPool {
             let send_ip_broadcast_rxs = pcap_result.receivers;
 
             // 各宛先IPアドレスに対してPing Worker（およびTraceroute Worker）を起動
-            let ping_target_len = ping_targets.targets.len();
             for ping_target in &ping_targets.targets {
                 let src_addr = Self::get_source_addr_for_target(ping_targets, &ping_target.host)?;
 
@@ -103,7 +105,7 @@ impl WorkerPool {
                 if cfg.traceroute.enable {
                     let traceroute_worker = TracerouteWorker::new(
                         token.clone(),
-                        ping_target.id + ping_target_len as u16,
+                        ping_target.id + total_target_count,
                         src_addr,
                         ping_target.host,
                         cfg.interval,
@@ -387,6 +389,58 @@ mod tests {
             Err(_) => {
                 // 環境制約で失敗することを許容
             }
+        }
+    }
+
+    #[test]
+    fn test_traceroute_id_calculation() {
+        // [正常系] TracerouteのID計算の一貫性確認
+        let token = CancellationToken::new();
+        let arp_table = Arc::new(ArpTable::new(&ArpConfig::default()));
+        let mut config = create_test_config();
+        config.traceroute.enable = true;
+        let mut targets = FxHashMap::default();
+
+        // 複数のターゲットを設定
+        let ni = create_test_network_interface();
+        let ping_targets = PingTargets {
+            ni: ni.clone(),
+            targets: vec![
+                crate::core::pcap_worker::PingTarget {
+                    id: 1,
+                    host: Ipv4Addr::new(192, 168, 1, 1),
+                },
+                crate::core::pcap_worker::PingTarget {
+                    id: 2,
+                    host: Ipv4Addr::new(192, 168, 1, 2),
+                },
+                crate::core::pcap_worker::PingTarget {
+                    id: 3,
+                    host: Ipv4Addr::new(192, 168, 1, 3),
+                },
+            ],
+        };
+        targets.insert(ni.index, ping_targets);
+        let (update_tx, _update_rx) = mpsc::channel::<UpdateMessage>(100);
+
+        // 全体のターゲット数を計算（実際の実装と同じロジック）
+        let total_target_count = targets.values().map(|pt| pt.targets.len()).sum::<usize>() as u16;
+        assert_eq!(total_target_count, 3);
+
+        // TracerouteのIDが正しく計算されることを確認
+        // ping_id=1のTracerouteIDは1+3=4
+        // ping_id=2のTracerouteIDは2+3=5
+        // ping_id=3のTracerouteIDは3+3=6
+        let expected_traceroute_ids = vec![4, 5, 6];
+
+        // TUI側の逆算ロジックでも正しく元のping_idが取得できることを確認
+        for (i, &expected_id) in expected_traceroute_ids.iter().enumerate() {
+            let original_ping_id = if expected_id >= total_target_count {
+                expected_id - total_target_count
+            } else {
+                expected_id
+            };
+            assert_eq!(original_ping_id, (i + 1) as u16);
         }
     }
 }

--- a/src/core/worker_pool.rs
+++ b/src/core/worker_pool.rs
@@ -395,8 +395,6 @@ mod tests {
     #[test]
     fn test_traceroute_id_calculation() {
         // [正常系] TracerouteのID計算の一貫性確認
-        let token = CancellationToken::new();
-        let arp_table = Arc::new(ArpTable::new(&ArpConfig::default()));
         let mut config = create_test_config();
         config.traceroute.enable = true;
         let mut targets = FxHashMap::default();
@@ -421,7 +419,6 @@ mod tests {
             ],
         };
         targets.insert(ni.index, ping_targets);
-        let (update_tx, _update_rx) = mpsc::channel::<UpdateMessage>(100);
 
         // 全体のターゲット数を計算（実際の実装と同じロジック）
         let total_target_count = targets.values().map(|pt| pt.targets.len()).sum::<usize>() as u16;
@@ -431,7 +428,7 @@ mod tests {
         // ping_id=1のTracerouteIDは1+3=4
         // ping_id=2のTracerouteIDは2+3=5
         // ping_id=3のTracerouteIDは3+3=6
-        let expected_traceroute_ids = vec![4, 5, 6];
+        let expected_traceroute_ids = [4, 5, 6];
 
         // TUI側の逆算ロジックでも正しく元のping_idが取得できることを確認
         for (i, &expected_id) in expected_traceroute_ids.iter().enumerate() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,6 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
     let config = Config::load(&cli.config)?;
 
-    let targets: Vec<String> = config.targets.iter().map(|t| t.name.to_string()).collect();
-
     // UpdateMessage用のチャネルを作成
     let (update_sender, update_receiver) = mpsc::channel::<UpdateMessage>(1000);
     let token = CancellationToken::new();
@@ -42,8 +40,7 @@ async fn main() -> Result<()> {
 
     // TUIタスクを起動
     let tui_handle = tokio::spawn(async move {
-        if let Err(e) = tui::run_tui(token.clone(), targets, update_receiver, &config_for_tui).await
-        {
+        if let Err(e) = tui::run_tui(token.clone(), update_receiver, &config_for_tui).await {
             eprintln!("TUIでエラーが発生しました: {e}");
         }
     });

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -14,12 +14,11 @@ use ui::render;
 
 pub async fn run_tui(
     token: CancellationToken,
-    targets: Vec<String>,
     update_receiver: mpsc::Receiver<UpdateMessage>,
     config: &crate::config::Config,
 ) -> Result<()> {
     let terminal = ratatui::init();
-    let result = run(token, terminal, targets, update_receiver, config).await;
+    let result = run(token, terminal, update_receiver, config).await;
     ratatui::restore();
     result
 }
@@ -27,13 +26,12 @@ pub async fn run_tui(
 async fn run(
     token: CancellationToken,
     mut terminal: DefaultTerminal,
-    targets: Vec<String>,
     mut update_receiver: mpsc::Receiver<UpdateMessage>,
     config: &crate::config::Config,
 ) -> Result<()> {
     let mut events = EventHandler::new();
     let event_sender = events.get_sender();
-    let mut app_state = AppState::new(targets, config);
+    let mut app_state = AppState::new(config);
 
     loop {
         tokio::select! {


### PR DESCRIPTION
## 概要
- TracerouteのID計算ロジックのバグを修正
- 設定ファイルの順序を保持したターゲット表示順序の改善
- 不要なitertools依存関係の削除とコード整理

## 主な変更点
### バグ修正
- `src/core/worker_pool.rs`: TracerouteのID計算で使用する基準値を`ping_target_len`から`total_target_count`に修正
- 複数のネットワークインターフェースを使用する場合の正しいID割り当てを実現

### 機能改善
- `src/core.rs`: itertools依存関係を削除し、設定ファイルの順序を保持したターゲット表示に変更
- `src/main.rs`: 不要なtargetsベクトルを削除し、TUI関数シグネチャを簡略化
- `src/tui.rs`: TUI関数から不要なtargetsパラメータを削除
- `src/tui/models.rs`: AppStateの初期化方法を修正し、設定ファイルの順序に従った結果表示を実現

## テスト追加
- TracerouteのID計算の一貫性確認テスト
- 設定ファイル順序保持の確認テスト

## 動作確認
- [x] cargo buildが成功すること
- [x] cargo testが成功すること
- [x] cargo clippyでエラーが発生しないこと
- [ ] 設定ファイルの順序通りにターゲットが表示されること
- [ ] TracerouteのIDが正しく計算されること

Fixes #26