### PR TITLE
fix 🐛: release-pr.yamlワークフローの構文エラー修正

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -37,7 +37,8 @@ jobs:
         LABELS=$(gh pr view $PR_NUMBER --json labels --jq '.labels[].name')
 
         # major/minor/patchラベルがあるかチェック
-        if echo "$LABELS" | grep -vqE '^(major|minor|patch)$'; then
+        if ! echo "$LABELS" | grep -qE '^(major|minor|patch)$'; then
+          echo "Error: PR must have one of major/minor/patch labels"
           exit 1
         fi
 
@@ -49,6 +50,9 @@ jobs:
         elif echo "$LABELS" | grep -q 'patch'; then
           echo "label=patch" >> $GITHUB_OUTPUT
         else
+          echo "Error: No valid release label found"
+          exit 1
+        fi
 
   prepare-release:
     name: Prepare Release


### PR DESCRIPTION
## 概要
PR #34のCI失敗の原因となっていたrelease-pr.yamlワークフローの構文エラーを修正

## 変更内容
- ラベルチェック条件の論理演算子を修正（`grep -vqE` → `\! grep -qE`）
- 適切なエラーメッセージを追加
- 未完了のelse節を完了

## 修正したエラー
- 40行目の条件分岐で論理演算子が不正確だった問題
- else節が未完了で構文エラーが発生していた問題

## テスト
- ワークフローファイルの構文チェック完了
- GitHub ActionsでCI実行確認予定