### PR TITLE
fix 🐛: Release WorkflowのJSONフォーマットエラーの修正

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -91,7 +91,7 @@ jobs:
       id: get-versions
       run: |
         versions="$(cargo metadata --format-version=1 --no-deps | \
-        jq '
+        jq -c '
             ( .workspace_members | map({key: ., value: true}) | from_entries ) as $ws_members |
             [
                 .packages[] |


### PR DESCRIPTION
## 概要
Release WorkflowのJSONフォーマットエラーを修正する

## 変更内容
- jqコマンドに-cフラグを追加してコンパクトなJSON出力に変更する
- GitHub ActionsでのJSON出力エラーを解決する

## 修正理由
CIで以下のエラーが発生する：
```
Error: Unable to process file command 'output' successfully.
Error: Invalid format '  "pcap": "1.0.0",'
```

jqコマンドがマルチライン出力するため、GitHub ActionsのJSON処理でエラーが発生する。