### PR TITLE
fix 🐛: CI WorkflowでのMISE_ENV設定エラーの修正

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -134,7 +134,7 @@ jobs:
           # - ubuntu-latest
           - macos-latest
     env:
-      MISE_ENV: ci,cov
+      MISE_ENV: ci-base,cov
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MISE_ENV: ci
+  MISE_ENV: ci-base
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: check-labels
     env:
-      MISE_ENV: ci,release
+      MISE_ENV: ci-base,release
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -83,6 +83,8 @@ jobs:
 
     - name: Install mise
       uses: jdx/mise-action@v2
+      with:
+        cache: false
 
     - name: Install tools with mise
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MISE_ENV: ci
+  MISE_ENV: ci-base
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,8 @@ gh api -X PATCH repos/{owner}/{repo}/issues/{issue_number}/sub_issues/priority -
 
 ### Branch Naming Convention
 - Branch names MUST follow the pattern: `[feature or bugfix or etc.]/[Issue番号 or PR番号]`
-- Examples: `feature/11`, `bugfix/23`, `hotfix/34`
+- Optionally, additional description can be added after the issue/PR number: `[feature or bugfix or etc.]/[Issue番号 or PR番号]_[description]`
+- Examples: `feature/11`, `bugfix/23`, `hotfix/34`, `feature/999_hoge_fuga`
 - **ALWAYS create branches from the latest main branch**
 - Before creating a new branch, ensure you are on main and pull the latest changes
 


### PR DESCRIPTION
## 概要
- CI WorkflowでのMISE_ENV設定エラーを修正
- ブランチ命名規則のドキュメントを更新

## 変更内容
- 3つのワークフローファイル（pr.yaml, release-pr.yaml, release.yaml）でMISE_ENVを`ci`から`ci-base`に変更
- CLAUDE.mdでブランチ命名規則に説明付与の例を追加

## 修正理由
- PR #40で発生したCIエラーを解決するため
- ブランチ命名規則をより柔軟に使用できるよう文書化

## テスト計画
- [x] CIワークフローが正常に動作することを確認
- [x] ドキュメントの記述が正確であることを確認