### PR TITLE
fix 🐛: Release WorkflowでのCIエラー修正 - 未コミット変更確認ステップの追加

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -220,7 +220,18 @@ jobs:
 
         echo "new-versions=$new_versions_json" >> $GITHUB_OUTPUT
 
+    - name: Check updated files
+      id: check-updated-files
+      run: |
+        # Check if there are any uncommitted changes
+        if [ -n "$(git status --porcelain)" ]; then
+          echo "has-changes=true" >> $GITHUB_OUTPUT
+        else
+          echo "has-changes=false" >> $GITHUB_OUTPUT
+        fi
+
     - name: Create version bump commit and push to main
+      if: steps.check-updated-files.outputs.has-changes == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |


### PR DESCRIPTION
## 概要
Release WorkflowでCIエラーが発生していた問題を修正する。

## 変更内容
- 未コミットの変更が存在するかどうかを確認する新しいステップを追加
- `git status --porcelain`を使用して変更の有無を検出
- 変更がある場合のみバージョンアップコミットを実行するよう条件分岐を追加

## 修正理由
以前のワークフローでは、変更がない場合でもバージョンアップコミットを実行しようとしてエラーが発生していた。この修正により、実際に変更がある場合のみコミットが実行されるようになる。

## テスト計画
- [ ] 変更がない場合のワークフロー実行
- [ ] 変更がある場合のワークフロー実行
- [ ] CI/CD パイプラインの正常動作確認