### PR TITLE
ci 🔧: PRワークフローにpermissions設定を追加

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -81,17 +81,6 @@ jobs:
         run: |
           brew install libpcap
 
-      - name: Cache mise tools
-        uses: actions/cache@v4
-        if: needs.changed-files.outputs.rust == 'true'
-        with:
-          path: |
-            ~/.local/share/mise
-            ~/.cache/mise
-          key: ${{ runner.os }}-mise-${{ hashFiles('mise.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-mise-
-
       - name: Install mise
         uses: jdx/mise-action@v2
         if: needs.changed-files.outputs.rust == 'true'
@@ -171,20 +160,8 @@ jobs:
         run: |
           brew install libpcap
 
-      - name: Cache mise tools
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.local/share/mise
-            ~/.cache/mise
-          key: ${{ runner.os }}-mise-${{ hashFiles('mise.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-mise-
-
       - name: Install mise
         uses: jdx/mise-action@v2
-        with:
-          cache: false
 
       - name: Install tools with mise
         run: |

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -74,20 +74,8 @@ jobs:
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
 
-    - name: Cache mise tools
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.local/share/mise
-          ~/.cache/mise
-        key: ${{ runner.os }}-mise-${{ hashFiles('mise.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-mise-
-
     - name: Install mise
       uses: jdx/mise-action@v2
-      with:
-        cache: false
 
     - name: Install tools with mise
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,16 +86,6 @@ jobs:
         run: |
           brew install libpcap mold
 
-      - name: Cache mise tools
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.local/share/mise
-            ~/.cache/mise
-          key: ${{ runner.os }}-mise-${{ hashFiles('mise.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-mise-
-
       - name: Install mise
         uses: jdx/mise-action@v2
 


### PR DESCRIPTION
## 概要
- PRワークフローファイルにpermissions設定を追加
- miseでGithub Actionsのキャッシュを使用するように改善

## 変更内容
- GitHub Actionsワークフローファイル（pr.yaml、release-pr.yaml、release.yaml）にpermissions設定を追加
- mise-actionのキャッシュ機能を活用し、手動キャッシュ設定を削除