### PR TITLE
fix 🐛: Release PRワークフローでのタグ作成失敗問題の修正

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -131,12 +131,15 @@ jobs:
 
     - name: Get updated crates
       id: get-updated-crates
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         # Get crate names from the previous step's output
         crate_names=($(echo '${{ steps.get-versions.outputs.versions }}' | jq -r 'keys[]'))
 
-        # Get changed files between main and release branches
-        changed_files=$(git diff --name-only origin/main...origin/release)
+        # Get changed files from the PR
+        PR_NUMBER=${{ github.event.pull_request.number }}
+        changed_files=$(gh pr view $PR_NUMBER --json files --jq '.files[].path')
 
         # Find which crates have been updated
         updated_crates=()


### PR DESCRIPTION
## 概要
Release PRワークフローでタグが作成されない問題を修正

## 問題の詳細
Release PRワークフロー（#34）が成功したにも関わらず、タグが作成されていなかった。原因は「Get updated crates」ステップで更新されたクレートが正しく検出されていなかったため。

## 根本原因
- PRマージ後にmainとreleaseブランチの差分がなくなるため、`git diff origin/main...origin/release` では変更ファイルが検出されない
- 結果として `updated_crates` が空になり、タグ作成のforループが実行されない

## 修正内容
- 変更ファイル取得方法を `git diff` から `gh pr view` に変更
- PRの変更ファイルを直接取得することで、マージ後でも正確にクレートを検出
- GITHUB_TOKEN環境変数を追加

## 修正した箇所
- `.github/workflows/release-pr.yaml` の「Get updated crates」ステップ

## 検証結果
- PR #34のファイル変更でテスト済み：`alarmon,pcap,tcpip` の検出を確認
- PR #40のファイル変更でテスト済み：関係ないファイルのみの場合は検出されないことを確認

## 期待される効果
次回のRelease PRで正しくタグが作成され、リリースワークフローが動作する