### PR TITLE
feat: Linux環境対応の実装

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         os:
-          # - ubuntu-latest
+          - ubuntu-latest
           - macos-latest
 
     steps:
@@ -120,7 +120,7 @@ jobs:
     strategy:
       matrix:
         os:
-          # - ubuntu-latest
+          - ubuntu-latest
           - macos-latest
     env:
       MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci-base.toml:mise.cov.toml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
- "caps",
  "chrono",
  "clap",
  "color-eyre",
@@ -57,7 +56,6 @@ dependencies = [
  "serde",
  "serde_with",
  "socket2 0.6.0",
- "sudo2",
  "tcpip",
  "tempfile",
  "thiserror 2.0.12",
@@ -302,16 +300,6 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
-
-[[package]]
-name = "caps"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190baaad529bcfbde9e1a19022c42781bdb6ff9de25721abdb8fd98c0807730b"
-dependencies = [
- "libc",
- "thiserror 1.0.69",
-]
 
 [[package]]
 name = "cassowary"
@@ -2167,17 +2155,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sudo2"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ea68622345f3315c2cbd365edfc5bcbb22edddb1b8f2cf0b515605340bc6de"
-dependencies = [
- "libc",
- "tracing",
- "wildmatch",
-]
-
-[[package]]
 name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2374,9 +2351,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f271e09bde39ab52250160a67e88577e0559ad77e9085de6e9051a2c4353f8f8"
+checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
 dependencies = [
  "indexmap 2.10.0",
  "serde",
@@ -2398,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c1c469eda89749d2230d8156a5969a69ffe0d6d01200581cdc6110674d293e"
+checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
 dependencies = [
  "winnow",
 ]
@@ -2678,12 +2655,6 @@ checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "wildmatch"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ce1ab1f8c62655ebe1350f589c61e505cf94d385bc6a12899442d9081e71fd"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
+ "caps",
  "chrono",
  "clap",
  "color-eyre",
@@ -45,6 +46,8 @@ dependencies = [
  "libc",
  "log",
  "mockall",
+ "netlink-packet-core",
+ "netlink-packet-route",
  "nix 0.30.1",
  "parking_lot",
  "pcap 1.0.0",
@@ -54,6 +57,7 @@ dependencies = [
  "serde",
  "serde_with",
  "socket2 0.6.0",
+ "sudo2",
  "tcpip",
  "tempfile",
  "thiserror 2.0.12",
@@ -298,6 +302,16 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "caps"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190baaad529bcfbde9e1a19022c42781bdb6ff9de25721abdb8fd98c0807730b"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "cassowary"
@@ -2153,6 +2167,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sudo2"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6ea68622345f3315c2cbd365edfc5bcbb22edddb1b8f2cf0b515605340bc6de"
+dependencies = [
+ "libc",
+ "tracing",
+ "wildmatch",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2653,6 +2678,12 @@ checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wildmatch"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ce1ab1f8c62655ebe1350f589c61e505cf94d385bc6a12899442d9081e71fd"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,10 @@ crossterm = { version = "0.29.0", features = ["event-stream"] }
 color-eyre = "0.6.3"
 futures = "0.3"
 console-subscriber = { version = "0.4.1", optional = true }
+netlink-packet-route = "0.24.0"
+netlink-packet-core = "0.7.0"
+caps = "0.5.5"
+sudo2 = "0.2.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rtnetlink = "0.17.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ tokio.workspace = true
 tcpip.workspace = true
 thiserror.workspace = true
 clap = { version = "4.5.41", features = ["derive"] }
-toml = "0.9.0"
+toml = "0.9.2"
 log = "0.4.27"
 env_logger = "0.11.8"
 chrono.workspace = true
@@ -64,8 +64,6 @@ futures = "0.3"
 console-subscriber = { version = "0.4.1", optional = true }
 netlink-packet-route = "0.24.0"
 netlink-packet-core = "0.7.0"
-caps = "0.5.5"
-sudo2 = "0.2.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rtnetlink = "0.17.0"

--- a/src/core.rs
+++ b/src/core.rs
@@ -31,9 +31,9 @@ pub async fn run_ping_monitoring(
         let id = target_config.id;
         let target_ip = Ipv4Addr::from_str(&target_config.host)?;
 
-        // LinkTypeを確認（Ethernetのみサポート）
-        let netlink = Netlink::new()?;
-        let route = netlink.get_route(target_ip)?;
+        // LinkTypeを確認
+        let netlink = Netlink::new().await?;
+        let route = netlink.get_route(target_ip).await?;
 
         let ping_targets = ping_targets_by_ni
             .entry(route.interface.index)

--- a/src/core.rs
+++ b/src/core.rs
@@ -33,6 +33,8 @@ pub async fn run_ping_monitoring(
 
         // LinkTypeを確認
         let netlink = Netlink::new().await?;
+        #[cfg(target_os = "linux")]
+        let mut netlink = netlink;
         let route = netlink.get_route(target_ip).await?;
 
         let ping_targets = ping_targets_by_ni

--- a/src/core/ping_worker.rs
+++ b/src/core/ping_worker.rs
@@ -424,9 +424,11 @@ mod tests {
         let identifier = 12345;
         let pending_pings = FxHashMap::default();
         let (_tx1, rx) = broadcast::channel(100);
+        #[cfg(target_os = "linux")]
         let (tx, _rx2) = mpsc::channel(100);
         let (_ping_tx, ping_rx) = mpsc::channel(100);
         let (update_tx, _update_rx) = mpsc::channel(100);
+        #[cfg(target_os = "linux")]
         let src = Ipv4Addr::new(192, 168, 1, 100);
 
         let receiver = PingResponseReceiver {
@@ -508,9 +510,11 @@ mod tests {
         );
 
         let (_tx, rx) = broadcast::channel(100);
+        #[cfg(target_os = "linux")]
         let (tx, _rx2) = mpsc::channel(100);
         let (_ping_tx, ping_rx) = mpsc::channel(100);
         let (update_tx, _update_rx) = mpsc::channel(100);
+        #[cfg(target_os = "linux")]
         let src = Ipv4Addr::new(192, 168, 1, 100);
 
         let mut receiver = PingResponseReceiver {
@@ -726,10 +730,12 @@ mod tests {
         let identifier = 12345;
         let pending_pings = FxHashMap::default();
         let (tx, rx) = broadcast::channel(100);
+        #[cfg(target_os = "linux")]
         let (tx2, _rx2) = mpsc::channel(100);
         let (ping_tx, ping_rx) = mpsc::channel(100);
 
         let (update_tx, _update_rx) = mpsc::channel(100);
+        #[cfg(target_os = "linux")]
         let src = Ipv4Addr::new(192, 168, 1, 100);
         let receiver = PingResponseReceiver {
             identifier,
@@ -794,10 +800,12 @@ mod tests {
         let identifier = 12345;
         let pending_pings = FxHashMap::default();
         let (_tx, rx) = broadcast::channel(100);
+        #[cfg(target_os = "linux")]
         let (tx, _rx2) = mpsc::channel(100);
         let (_ping_tx, ping_rx) = mpsc::channel(100);
 
         let (update_tx, _update_rx) = mpsc::channel(100);
+        #[cfg(target_os = "linux")]
         let src = Ipv4Addr::new(192, 168, 1, 100);
         let mut receiver = PingResponseReceiver {
             identifier,

--- a/src/core/ping_worker.rs
+++ b/src/core/ping_worker.rs
@@ -65,11 +65,25 @@ pub struct PingResponseReceiver {
     /// IPパケットを受信するためのチャネル
     rx: broadcast::Receiver<TimestampedPacket>,
 
+    /// IPパケットを送信するためのチャネル
+    /// Linuxの場合にのみ必要
+    #[cfg(target_os = "linux")]
+    tx: mpsc::Sender<IPv4Packet>,
+
     /// 送信通知受信用チャネル
     ping_rx: mpsc::Receiver<PendingPing>,
 
     /// UpdateMessage送信用チャネル
     update_tx: mpsc::Sender<UpdateMessage>,
+
+    /// ICMPメッセージを手動で返信する必要があるかどうか
+    /// Linuxの場合は自分自身にパケットを送信した場合にKernelのプロトコルスタックを通過しないので、Echo Reply Messageを作成して返す必要がある
+    #[cfg(target_os = "linux")]
+    self_reply: bool,
+
+    /// 送信元IPアドレス
+    #[cfg(target_os = "linux")]
+    src: Ipv4Addr,
 }
 
 pub struct PingWorker {
@@ -94,23 +108,27 @@ impl PingWorker {
 
         // 送信通知用チャネルを作成
         let (ping_tx, ping_rx) = mpsc::channel(1000);
-
         let sender = PingRequestSender {
             identifier: id,
             sequence_counter: 0,
             src,
             target,
             interval,
-            tx,
+            tx: tx.clone(),
             ping_tx,
         };
-
         let receiver = PingResponseReceiver {
             identifier: id,
             pending_pings: pendings,
             rx,
+            #[cfg(target_os = "linux")]
+            tx,
             ping_rx,
             update_tx,
+            #[cfg(target_os = "linux")]
+            self_reply: src == target, // 送信元IPアドレスと宛先IPアドレスが同じ == 自身に対してのICMP Echo Requestを送信
+            #[cfg(target_os = "linux")]
+            src, // 送信元IPアドレスを保持
         };
 
         Self {
@@ -224,41 +242,64 @@ impl PingResponseReceiver {
         let pkt = timestamped_pkt.packet;
         let received_at = timestamped_pkt.received_at;
         let icmp_msg = ICMPMessage::try_from(&pkt.payload)?;
-        if let ICMPMessage::EchoReply(msg) = icmp_msg {
-            let id = msg.identifier;
-            if id != self.identifier {
-                debug!(
-                    "Received Echo Reply with different identifier. Expected: {}, Received: {}",
-                    id, self.identifier
+        match icmp_msg {
+            ICMPMessage::EchoReply(msg) => {
+                let id = msg.identifier;
+                if id != self.identifier {
+                    debug!(
+                        "Received Echo Reply with different identifier. Expected: {}, Received: {}",
+                        id, self.identifier
+                    );
+                    return Ok(());
+                }
+
+                let seq = msg.sequence_number;
+                if !self.pending_pings.contains_key(&seq) {
+                    debug!("Received Echo Reply with unknown sequence number: {seq}");
+                    return Ok(());
+                }
+                let pending_ping = self.pending_pings.remove(&seq).unwrap();
+
+                let latency = received_at - pending_ping.sent_at;
+
+                // TUIへのUpdateMessage送信
+                let ping_update = PingUpdate {
+                    id: self.identifier,
+                    host: pending_ping.target_ip,
+                    success: true,
+                    latency: Some(Duration::milliseconds(latency.num_milliseconds())),
+                };
+
+                if let Err(e) = self.update_tx.send(UpdateMessage::Ping(ping_update)).await {
+                    warn!("Failed to send ping update to TUI: {e}");
+                }
+            }
+            #[cfg(target_os = "linux")]
+            ICMPMessage::Echo(msg) if self.self_reply && pkt.dst == self.src => {
+                // Linuxの場合は自分自身にパケットを送信した場合にKernelのプロトコルスタックを通過しないので、Echo Reply Messageを作成して返す必要がある
+                let reply_msg =
+                    ICMPMessage::echo_reply(msg.identifier, msg.sequence_number, msg.data);
+                let icmp_bytes: Bytes = reply_msg.into();
+                let pkt = IPv4Packet::new(
+                    TypeOfService::default(),
+                    self.identifier,
+                    Flags::default(),
+                    0,
+                    64,
+                    Protocol::ICMP,
+                    self.src,
+                    self.src, // 自分自身に返信
+                    Vec::new(),
+                    icmp_bytes,
                 );
-                return Ok(());
+                self.tx
+                    .send(pkt)
+                    .await
+                    .map_err(|_| PingWorkerError::ChannelSendError)?;
             }
-
-            let seq = msg.sequence_number;
-            if !self.pending_pings.contains_key(&seq) {
-                debug!("Received Echo Reply with unknown sequence number: {seq}");
-                return Ok(());
+            msg => {
+                debug!("Received message is not Echo Reply: {}", msg.message_type());
             }
-            let pending_ping = self.pending_pings.remove(&seq).unwrap();
-
-            let latency = received_at - pending_ping.sent_at;
-
-            // TUIへのUpdateMessage送信
-            let ping_update = PingUpdate {
-                id: self.identifier,
-                host: pending_ping.target_ip,
-                success: true,
-                latency: Some(Duration::milliseconds(latency.num_milliseconds())),
-            };
-
-            if let Err(e) = self.update_tx.send(UpdateMessage::Ping(ping_update)).await {
-                warn!("Failed to send ping update to TUI: {e}");
-            }
-        } else {
-            debug!(
-                "Received message is not Echo Reply: {}",
-                icmp_msg.message_type()
-            );
         }
 
         Ok(())
@@ -383,15 +424,23 @@ mod tests {
         let identifier = 12345;
         let pending_pings = FxHashMap::default();
         let (_tx1, rx) = broadcast::channel(100);
+        let (tx, _rx2) = mpsc::channel(100);
         let (_ping_tx, ping_rx) = mpsc::channel(100);
         let (update_tx, _update_rx) = mpsc::channel(100);
+        let src = Ipv4Addr::new(192, 168, 1, 100);
 
         let receiver = PingResponseReceiver {
             identifier,
             pending_pings,
             rx,
+            #[cfg(target_os = "linux")]
+            tx,
             ping_rx,
             update_tx,
+            #[cfg(target_os = "linux")]
+            self_reply: false,
+            #[cfg(target_os = "linux")]
+            src,
         };
 
         assert_eq!(receiver.identifier, identifier);
@@ -459,15 +508,23 @@ mod tests {
         );
 
         let (_tx, rx) = broadcast::channel(100);
+        let (tx, _rx2) = mpsc::channel(100);
         let (_ping_tx, ping_rx) = mpsc::channel(100);
         let (update_tx, _update_rx) = mpsc::channel(100);
+        let src = Ipv4Addr::new(192, 168, 1, 100);
 
         let mut receiver = PingResponseReceiver {
             identifier,
             pending_pings,
             rx,
+            #[cfg(target_os = "linux")]
+            tx,
             ping_rx,
             update_tx,
+            #[cfg(target_os = "linux")]
+            self_reply: false,
+            #[cfg(target_os = "linux")]
+            src,
         };
 
         // ICMP Echo Replyパケットを作成
@@ -669,15 +726,23 @@ mod tests {
         let identifier = 12345;
         let pending_pings = FxHashMap::default();
         let (tx, rx) = broadcast::channel(100);
+        let (tx2, _rx2) = mpsc::channel(100);
         let (ping_tx, ping_rx) = mpsc::channel(100);
 
         let (update_tx, _update_rx) = mpsc::channel(100);
+        let src = Ipv4Addr::new(192, 168, 1, 100);
         let receiver = PingResponseReceiver {
             identifier,
             pending_pings,
             rx,
+            #[cfg(target_os = "linux")]
+            tx: tx2,
             ping_rx,
             update_tx,
+            #[cfg(target_os = "linux")]
+            self_reply: false,
+            #[cfg(target_os = "linux")]
+            src,
         };
 
         // 送信通知を送る
@@ -729,15 +794,23 @@ mod tests {
         let identifier = 12345;
         let pending_pings = FxHashMap::default();
         let (_tx, rx) = broadcast::channel(100);
+        let (tx, _rx2) = mpsc::channel(100);
         let (_ping_tx, ping_rx) = mpsc::channel(100);
 
         let (update_tx, _update_rx) = mpsc::channel(100);
+        let src = Ipv4Addr::new(192, 168, 1, 100);
         let mut receiver = PingResponseReceiver {
             identifier,
             pending_pings,
             rx,
+            #[cfg(target_os = "linux")]
+            tx,
             ping_rx,
             update_tx,
+            #[cfg(target_os = "linux")]
+            self_reply: false,
+            #[cfg(target_os = "linux")]
+            src,
         };
 
         // 不正なICMPペイロードのIPパケット

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<()> {
         {
             let err_msg = format!("Error has occurred in ping monitoring: {e}");
             ratatui::restore();
-            error!("{}", err_msg);
+            error!("{err_msg}");
         }
     });
 
@@ -49,7 +49,7 @@ async fn main() -> Result<()> {
         if let Err(e) = tui::run_tui(token.clone(), update_receiver, &config_for_tui).await {
             let err_msg = format!("Error has occurred in TUI: {e}");
             ratatui::restore();
-            error!("{}", err_msg);
+            error!("{err_msg}");
         }
     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
-use color_eyre::Result;
+use anyhow::Result;
 use config::Config;
+use env_logger::Env;
+use log::error;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tui::models::UpdateMessage;
@@ -14,9 +16,15 @@ mod tui;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    #[cfg(target_os = "linux")]
+    prepare()?;
     #[cfg(all(debug_assertions, feature = "tokio-console"))]
     console_subscriber::init();
-    color_eyre::install()?;
+    env_logger::init_from_env(Env::default().default_filter_or("info"));
+    color_eyre::install().map_err(|e| {
+        error!("Failed to install color_eyre: {e}");
+        anyhow::anyhow!("Failed to install color_eyre")
+    })?;
 
     let cli = Cli::parse();
     let config = Config::load(&cli.config)?;
@@ -25,31 +33,53 @@ async fn main() -> Result<()> {
     let (update_sender, update_receiver) = mpsc::channel::<UpdateMessage>(1000);
     let token = CancellationToken::new();
 
-    // 複数のタスクでconfigを使用するためクローンを作成
-    let config_for_ping = config.clone();
-    let config_for_tui = config.clone();
-
     // Ping監視タスクを起動
     let ping_token = token.clone();
+    let config_for_ping = config.clone();
     let ping_handle = tokio::spawn(async move {
         if let Err(e) = core::run_ping_monitoring(ping_token, &config_for_ping, update_sender).await
         {
-            eprintln!("Ping監視でエラーが発生しました: {e}");
+            let err_msg = format!("Error has occurred in ping monitoring: {e}");
+            ratatui::restore();
+            error!("{}", err_msg);
         }
     });
 
     // TUIタスクを起動
-    let tui_handle = tokio::spawn(async move {
-        if let Err(e) = tui::run_tui(token.clone(), update_receiver, &config_for_tui).await {
-            eprintln!("TUIでエラーが発生しました: {e}");
-        }
-    });
+    // let config_for_tui = config.clone();
+    // let tui_handle = tokio::spawn(async move {
+    //     if let Err(e) = tui::run_tui(token.clone(), update_receiver, &config_for_tui).await {
+    //         let err_msg = format!("Error has occurred in TUI: {e}");
+    //         ratatui::restore();
+    //         error!("{}", err_msg);
+    //     }
+    // });
 
     // どちらかのタスクが終了するまで待機
     tokio::select! {
         _ = ping_handle => {},
-        _ = tui_handle => {},
+        // _ = tui_handle => {},
     }
 
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn prepare() -> anyhow::Result<()> {
+    use caps::{CapSet, Capability};
+    use sudo2::{running_as_root, running_as_suid};
+
+    if !(running_as_root() || running_as_suid())
+        && !caps::has_cap(None, CapSet::Permitted, Capability::CAP_NET_RAW)?
+    {
+        sudo2::escalate_with_env().map_err(|e| {
+            error!("Failed to escalate privileges: {e}");
+            anyhow::anyhow!("Failed to escalate privileges")
+        })?;
+    }
+
+    caps::set(None, CapSet::Permitted, &[Capability::CAP_NET_RAW].into())?;
+    caps::set(None, CapSet::Inheritable, &[Capability::CAP_NET_RAW].into())?;
+    caps::set(None, CapSet::Effective, &[Capability::CAP_NET_RAW].into())?;
     Ok(())
 }

--- a/src/net_utils/arp_table.rs
+++ b/src/net_utils/arp_table.rs
@@ -91,6 +91,8 @@ impl ArpTable {
 
         // キャッシュにない、または期限切れの場合はARP解決を実行
         let netlink = Netlink::new().await?;
+        #[cfg(target_os = "linux")]
+        let mut netlink = netlink;
         let best_route = netlink.get_route(target_ip).await?;
         let ni = pcap::NetworkInterface::from(&best_route.interface);
 

--- a/src/net_utils/arp_table.rs
+++ b/src/net_utils/arp_table.rs
@@ -90,8 +90,8 @@ impl ArpTable {
         }
 
         // キャッシュにない、または期限切れの場合はARP解決を実行
-        let netlink = Netlink::new()?;
-        let best_route = netlink.get_route(target_ip)?;
+        let netlink = Netlink::new().await?;
+        let best_route = netlink.get_route(target_ip).await?;
         let ni = pcap::NetworkInterface::from(&best_route.interface);
 
         let mac_addr = resolve_arp_with_pcap(target_ip, ni, best_route, self.arp_timeout).await?;

--- a/src/net_utils/netlink.rs
+++ b/src/net_utils/netlink.rs
@@ -1,35 +1,19 @@
-use std::io;
 use std::net::{IpAddr, Ipv4Addr};
 
 use tcpip::ethernet::MacAddr;
-use tcpip::ip_cidr::{IPCIDR, IPv4NetmaskError};
-use thiserror::Error;
+use tcpip::ip_cidr::IPCIDR;
 
+pub use self::common::NetlinkError;
+#[cfg(target_os = "linux")]
+pub use self::linux::Netlink;
 #[cfg(target_os = "macos")]
 pub use self::macos::Netlink;
 
+mod common;
+#[cfg(target_os = "linux")]
+mod linux;
 #[cfg(target_os = "macos")]
 mod macos;
-
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub enum NetlinkError {
-    #[error("Failed to get network interfaces: {0}")]
-    FailedToGetIfAddrs(#[source] nix::Error),
-    #[error("Failed to open socket: {0}")]
-    FailedToOpenSocket(io::ErrorKind),
-    #[error("No such network interface: index = {0}")]
-    NoSuchInterfaceIdx(u32),
-    #[error(transparent)]
-    InvalidNetmask(#[from] IPv4NetmaskError),
-    #[error("Unsupported link type: {0}")]
-    UnsupportedLinkType(u8),
-    #[cfg(target_os = "macos")]
-    #[error("PF_ROUTE send error: {0}")]
-    PfRouteSendError(io::ErrorKind),
-    #[cfg(target_os = "macos")]
-    #[error("PF_ROUTE receive error: {0}")]
-    PfRouteReceiveError(io::ErrorKind),
-}
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct NetworkInterface {

--- a/src/net_utils/netlink.rs
+++ b/src/net_utils/netlink.rs
@@ -1,13 +1,35 @@
+use std::io;
 use std::net::{IpAddr, Ipv4Addr};
 
 use tcpip::ethernet::MacAddr;
-use tcpip::ip_cidr::IPCIDR;
+use tcpip::ip_cidr::{IPCIDR, IPv4NetmaskError};
+use thiserror::Error;
 
 #[cfg(target_os = "macos")]
-pub use self::macos::{Netlink, NetlinkError};
+pub use self::macos::Netlink;
 
 #[cfg(target_os = "macos")]
 mod macos;
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum NetlinkError {
+    #[error("Failed to get network interfaces: {0}")]
+    FailedToGetIfAddrs(#[source] nix::Error),
+    #[error("Failed to open socket: {0}")]
+    FailedToOpenSocket(io::ErrorKind),
+    #[error("No such network interface: index = {0}")]
+    NoSuchInterfaceIdx(u32),
+    #[error(transparent)]
+    InvalidNetmask(#[from] IPv4NetmaskError),
+    #[error("Unsupported link type: {0}")]
+    UnsupportedLinkType(u8),
+    #[cfg(target_os = "macos")]
+    #[error("PF_ROUTE send error: {0}")]
+    PfRouteSendError(io::ErrorKind),
+    #[cfg(target_os = "macos")]
+    #[error("PF_ROUTE receive error: {0}")]
+    PfRouteReceiveError(io::ErrorKind),
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct NetworkInterface {

--- a/src/net_utils/netlink/common.rs
+++ b/src/net_utils/netlink/common.rs
@@ -1,0 +1,134 @@
+use std::io;
+
+use fxhash::FxHashMap;
+use nix::ifaddrs::getifaddrs;
+use nix::net::if_::{InterfaceFlags, if_nametoindex};
+use tcpip::ethernet::MacAddr;
+use tcpip::ip_cidr::{IPCIDR, IPv4CIDR, IPv4Netmask, IPv4NetmaskError};
+use thiserror::Error;
+
+use super::{Netlink, NetworkInterface};
+use crate::net_utils::netlink::LinkType;
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum NetlinkError {
+    #[error("Failed to get network interfaces: {0}")]
+    FailedToGetIfAddrs(#[source] nix::Error),
+    #[error("Failed to open socket: {0}")]
+    FailedToOpenSocket(io::ErrorKind),
+    #[error("No such network interface: index = {0}")]
+    NoSuchInterfaceIdx(u32),
+    #[error(transparent)]
+    InvalidNetmask(#[from] IPv4NetmaskError),
+    #[error("Unsupported link type: {0}")]
+    UnsupportedLinkType(u8),
+    #[cfg(target_os = "linux")]
+    #[error(transparent)]
+    RTNetlinkError(#[from] rtnetlink::Error),
+    #[cfg(target_os = "linux")]
+    #[error("Failed to get route message")]
+    FailedToGetRouteMessage,
+    #[cfg(target_os = "macos")]
+    #[error("PF_ROUTE send error: {0}")]
+    PfRouteSendError(io::ErrorKind),
+    #[cfg(target_os = "macos")]
+    #[error("PF_ROUTE receive error: {0}")]
+    PfRouteReceiveError(io::ErrorKind),
+}
+
+impl Netlink {
+    pub(super) fn get_interfaces(&self) -> Result<Vec<NetworkInterface>, NetlinkError> {
+        let ifaddrs = getifaddrs().map_err(NetlinkError::FailedToGetIfAddrs)?;
+        let mut interfaces: FxHashMap<String, NetworkInterface> = FxHashMap::default();
+
+        for ifaddr in ifaddrs {
+            let iface_name = ifaddr.interface_name.clone();
+
+            // 既存インターフェースを取得または新規作成
+            let iface = interfaces.entry(iface_name.clone()).or_insert_with(|| {
+                let index = if_nametoindex(iface_name.as_str())
+                    .map_err(NetlinkError::FailedToGetIfAddrs)
+                    .unwrap_or(0);
+                let linktype = if ifaddr.flags.contains(InterfaceFlags::IFF_LOOPBACK) {
+                    LinkType::Loopback
+                } else {
+                    // EthernetとRawIPをここで判別できない
+                    LinkType::Ethernet
+                };
+
+                NetworkInterface {
+                    index,
+                    name: iface_name,
+                    mac_addr: MacAddr::default(),
+                    ip_addrs: Vec::new(),
+                    linktype,
+                }
+            });
+            let Some(address) = ifaddr.address else {
+                continue;
+            };
+
+            // MACアドレスの処理
+            if let Some(mac_addr) = address.as_link_addr() {
+                if let Some(mac_bytes) = mac_addr.addr() {
+                    iface.mac_addr = mac_bytes.into();
+                }
+                continue;
+            }
+
+            // IPv4アドレスの処理
+            let Some(ipv4_addr) = address.as_sockaddr_in() else {
+                continue;
+            };
+            let Some(netmask) = ifaddr.netmask else {
+                continue;
+            };
+            let Some(netmask_addr) = netmask.as_sockaddr_in() else {
+                continue;
+            };
+            let Ok(netmask) = IPv4Netmask::try_from(netmask_addr.ip()) else {
+                continue;
+            };
+            let cidr = IPCIDR::V4(IPv4CIDR::new(ipv4_addr.ip(), netmask));
+            iface.ip_addrs.push(cidr);
+        }
+
+        Ok(interfaces.into_values().collect())
+    }
+
+    pub(super) fn get_interface_from_index(
+        &self,
+        index: u32,
+    ) -> Result<NetworkInterface, NetlinkError> {
+        let ifaces = self.get_interfaces()?;
+        ifaces
+            .into_iter()
+            .find(|iface| iface.index == index)
+            .ok_or(NetlinkError::NoSuchInterfaceIdx(index))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_get_interfaces() -> Result<()> {
+        // [正常系] インターフェース一覧の取得
+        let netlink = Netlink::new().await?;
+        let interfaces = netlink.get_interfaces()?;
+
+        // 最低1つはインターフェースが存在するはず（loopbackなど）
+        assert!(!interfaces.is_empty());
+
+        // 各インターフェースの基本的な構造を確認
+        for interface in interfaces {
+            assert!(!interface.name.is_empty());
+            assert!(interface.index > 0);
+        }
+
+        Ok(())
+    }
+}

--- a/src/net_utils/netlink/common.rs
+++ b/src/net_utils/netlink/common.rs
@@ -23,6 +23,7 @@ pub enum NetlinkError {
     #[error(transparent)]
     InvalidNetmask(#[from] IPv4NetmaskError),
     #[cfg(target_os = "linux")]
+    #[allow(clippy::enum_variant_names)]
     #[error(transparent)]
     RTNetlinkError(#[from] rtnetlink::Error),
     #[cfg(target_os = "linux")]

--- a/src/net_utils/netlink/common.rs
+++ b/src/net_utils/netlink/common.rs
@@ -1,6 +1,8 @@
 use std::io;
 
 use fxhash::FxHashMap;
+#[cfg(target_os = "linux")]
+use netlink_packet_route::link::LinkLayerType;
 use nix::ifaddrs::getifaddrs;
 use nix::net::if_::{InterfaceFlags, if_nametoindex};
 use tcpip::ethernet::MacAddr;
@@ -20,20 +22,24 @@ pub enum NetlinkError {
     NoSuchInterfaceIdx(u32),
     #[error(transparent)]
     InvalidNetmask(#[from] IPv4NetmaskError),
-    #[error("Unsupported link type: {0}")]
-    UnsupportedLinkType(u8),
     #[cfg(target_os = "linux")]
     #[error(transparent)]
     RTNetlinkError(#[from] rtnetlink::Error),
     #[cfg(target_os = "linux")]
     #[error("Failed to get route message")]
     FailedToGetRouteMessage,
+    #[cfg(target_os = "linux")]
+    #[error("Unsupported link type: {0}")]
+    UnsupportedLinkType(LinkLayerType),
     #[cfg(target_os = "macos")]
     #[error("PF_ROUTE send error: {0}")]
     PfRouteSendError(io::ErrorKind),
     #[cfg(target_os = "macos")]
     #[error("PF_ROUTE receive error: {0}")]
     PfRouteReceiveError(io::ErrorKind),
+    #[cfg(target_os = "macos")]
+    #[error("Unsupported link type: {0}")]
+    UnsupportedLinkType(u8),
 }
 
 impl Netlink {

--- a/src/net_utils/netlink/linux.rs
+++ b/src/net_utils/netlink/linux.rs
@@ -1,0 +1,129 @@
+use std::net::Ipv4Addr;
+
+use futures::future::{self, Either};
+use futures::{FutureExt, StreamExt as _, TryStream, TryStreamExt};
+use netlink_packet_core::NLM_F_REQUEST;
+use netlink_packet_route::route::{RouteAddress, RouteAttribute};
+use rtnetlink::packet_core::NetlinkMessage;
+use rtnetlink::packet_route::RouteNetlinkMessage;
+use rtnetlink::packet_route::route::{RouteMessage, RouteProtocol, RouteScope, RouteType};
+use rtnetlink::sys::AsyncSocket as _;
+use rtnetlink::{Handle, RouteMessageBuilder, new_connection, try_rtnl};
+
+use super::{NetlinkError, RouteEntry};
+
+pub struct Netlink {
+    handle: Handle,
+}
+impl Netlink {
+    pub async fn new() -> Result<Self, NetlinkError> {
+        let (mut conn, handle, _) =
+            new_connection().map_err(|e| NetlinkError::FailedToOpenSocket(e.kind()))?;
+        conn.socket_mut()
+            .socket_mut()
+            .set_netlink_get_strict_chk(true)
+            .map_err(|e| NetlinkError::FailedToOpenSocket(e.kind()))?;
+        tokio::spawn(conn);
+
+        Ok(Self { handle })
+    }
+
+    pub async fn get_route(&mut self, target_ip: Ipv4Addr) -> Result<RouteEntry, NetlinkError> {
+        let builder = RouteMessageBuilder::<Ipv4Addr>::new();
+        let req_msg = builder
+            .destination_prefix(target_ip, 32)
+            .table_id(0) // RT_TABLE_UNSPEC（C言語と同じ）
+            .protocol(RouteProtocol::Unspec) // RTPROT_UNSPEC（C言語と同じ）
+            .scope(RouteScope::Universe) // RT_SCOPE_UNIVERSE（C言語と同じ）
+            .kind(RouteType::Unspec) // RTN_UNSPEC（C言語と同じ）
+            .build();
+
+        let mut resp = self.execute_get_route_request(req_msg);
+        let resp_msg = resp
+            .try_next()
+            .await?
+            .ok_or(NetlinkError::FailedToGetRouteMessage)?;
+
+        self.parse_route_entry_from_route_msg(resp_msg)
+    }
+
+    fn execute_get_route_request(
+        &mut self,
+        msg: RouteMessage,
+    ) -> impl TryStream<Ok = RouteMessage, Error = rtnetlink::Error> + use<> {
+        let mut req = NetlinkMessage::from(RouteNetlinkMessage::GetRoute(msg));
+        req.header.flags = NLM_F_REQUEST;
+
+        match self.handle.request(req) {
+            Ok(resp) => {
+                Either::Left(resp.map(move |msg| Ok(try_rtnl!(msg, RouteNetlinkMessage::NewRoute))))
+            }
+            Err(e) => Either::Right(future::err::<RouteMessage, _>(e).into_stream()),
+        }
+    }
+
+    fn parse_route_entry_from_route_msg(
+        &self,
+        msg: RouteMessage,
+    ) -> Result<RouteEntry, NetlinkError> {
+        let mut iface_index = None;
+        let mut to = None;
+        let mut via = None;
+        for attr in msg.attributes {
+            match attr {
+                RouteAttribute::Oif(index) => {
+                    iface_index = Some(index);
+                }
+                RouteAttribute::Destination(addr) => match addr {
+                    RouteAddress::Inet(addr) => {
+                        to = Some(addr);
+                    }
+                    _ => unimplemented!(),
+                },
+                RouteAttribute::Gateway(addr) => match addr {
+                    RouteAddress::Inet(addr) => {
+                        via = Some(addr);
+                    }
+                    _ => unimplemented!(),
+                },
+                _ => {}
+            }
+        }
+
+        let interface = self.get_interface_from_index(iface_index.unwrap_or(0))?;
+        let entry = RouteEntry {
+            interface,
+            to: to.expect("dst address should be set").into(),
+            via: via.map(Into::into),
+        };
+
+        Ok(entry)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::IpAddr;
+
+    use anyhow::Result;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_get_route() -> Result<()> {
+        // [正常系] IPv4アドレスに対するルート取得
+        let mut netlink = Netlink::new().await?;
+
+        // ローカルホストへのルート取得をテスト
+        // let target_ip = Ipv4Addr::new(1, 1, 1, 1);
+        let target_ip = Ipv4Addr::new(10, 88, 0, 1);
+        // let target_ip = Ipv4Addr::new(127, 0, 0, 1);
+        let result = netlink.get_route(target_ip).await;
+        assert!(result.is_ok());
+        let route_entry = result.unwrap();
+        assert_eq!(route_entry.to, IpAddr::V4(target_ip));
+        assert!(!route_entry.interface.name.is_empty());
+
+        Ok(())
+    }
+}

--- a/src/net_utils/netlink/linux.rs
+++ b/src/net_utils/netlink/linux.rs
@@ -112,7 +112,6 @@ impl Netlink {
                 let rtnetlink::Error::NetlinkError(err_msg) = e.clone() else {
                     return NetlinkError::RTNetlinkError(e);
                 };
-                dbg!(&err_msg);
                 if err_msg.code.map(|c| c.abs()) == NonZeroI32::new(nix::libc::ENODEV) {
                     NetlinkError::NoSuchInterfaceIdx(index)
                 } else {
@@ -123,7 +122,7 @@ impl Netlink {
         match link.header.link_layer_type {
             LinkLayerType::Ether => Ok(LinkType::Ethernet),
             LinkLayerType::Loopback => Ok(LinkType::Loopback),
-            LinkLayerType::Rawip => Ok(LinkType::RawIP),
+            LinkLayerType::Rawip | LinkLayerType::None => Ok(LinkType::RawIP),
             _ => Err(NetlinkError::UnsupportedLinkType(
                 link.header.link_layer_type,
             )),

--- a/src/net_utils/netlink/linux.rs
+++ b/src/net_utils/netlink/linux.rs
@@ -1,8 +1,10 @@
 use std::net::Ipv4Addr;
+use std::num::NonZeroI32;
 
 use futures::future::{self, Either};
 use futures::{FutureExt, StreamExt as _, TryStream, TryStreamExt};
 use netlink_packet_core::NLM_F_REQUEST;
+use netlink_packet_route::link::LinkLayerType;
 use netlink_packet_route::route::{RouteAddress, RouteAttribute};
 use rtnetlink::packet_core::NetlinkMessage;
 use rtnetlink::packet_route::RouteNetlinkMessage;
@@ -10,7 +12,7 @@ use rtnetlink::packet_route::route::{RouteMessage, RouteProtocol, RouteScope, Ro
 use rtnetlink::sys::AsyncSocket as _;
 use rtnetlink::{Handle, RouteMessageBuilder, new_connection, try_rtnl};
 
-use super::{NetlinkError, RouteEntry};
+use super::{LinkType, NetlinkError, RouteEntry};
 
 pub struct Netlink {
     handle: Handle,
@@ -44,7 +46,7 @@ impl Netlink {
             .await?
             .ok_or(NetlinkError::FailedToGetRouteMessage)?;
 
-        self.parse_route_entry_from_route_msg(resp_msg)
+        self.parse_route_entry_from_route_msg(resp_msg).await
     }
 
     fn execute_get_route_request(
@@ -62,7 +64,7 @@ impl Netlink {
         }
     }
 
-    fn parse_route_entry_from_route_msg(
+    async fn parse_route_entry_from_route_msg(
         &self,
         msg: RouteMessage,
     ) -> Result<RouteEntry, NetlinkError> {
@@ -90,7 +92,8 @@ impl Netlink {
             }
         }
 
-        let interface = self.get_interface_from_index(iface_index.unwrap_or(0))?;
+        let mut interface = self.get_interface_from_index(iface_index.unwrap_or(0))?;
+        interface.linktype = self.get_linktype_from_index(interface.index).await?;
         let entry = RouteEntry {
             interface,
             to: to.expect("dst address should be set").into(),
@@ -99,6 +102,33 @@ impl Netlink {
 
         Ok(entry)
     }
+
+    async fn get_linktype_from_index(&self, index: u32) -> Result<LinkType, NetlinkError> {
+        let mut links = self.handle.link().get().match_index(index).execute();
+        let link = links
+            .try_next()
+            .await
+            .map_err(|e| {
+                let rtnetlink::Error::NetlinkError(err_msg) = e.clone() else {
+                    return NetlinkError::RTNetlinkError(e);
+                };
+                dbg!(&err_msg);
+                if err_msg.code.map(|c| c.abs()) == NonZeroI32::new(nix::libc::ENODEV) {
+                    NetlinkError::NoSuchInterfaceIdx(index)
+                } else {
+                    NetlinkError::RTNetlinkError(e)
+                }
+            })?
+            .ok_or(NetlinkError::NoSuchInterfaceIdx(index))?;
+        match link.header.link_layer_type {
+            LinkLayerType::Ether => Ok(LinkType::Ethernet),
+            LinkLayerType::Loopback => Ok(LinkType::Loopback),
+            LinkLayerType::Rawip => Ok(LinkType::RawIP),
+            _ => Err(NetlinkError::UnsupportedLinkType(
+                link.header.link_layer_type,
+            )),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -106,8 +136,39 @@ mod tests {
     use std::net::IpAddr;
 
     use anyhow::Result;
+    use rtnetlink::packet_route::route::{RouteProtocol, RouteScope, RouteType};
 
     use super::*;
+
+    #[tokio::test]
+    async fn test_get_linktype_from_index() -> Result<()> {
+        let netlink = Netlink::new().await?;
+
+        // [正常系] loopbackインターフェースのリンクタイプ取得
+        let result = netlink.get_linktype_from_index(1).await;
+        assert!(result.is_ok());
+        let linktype = result.unwrap();
+        assert_eq!(linktype, LinkType::Loopback);
+
+        // [正常系] 実際のインターフェースでリンクタイプ取得
+        let interfaces = netlink.get_interfaces()?;
+        if let Some(ethernet_iface) = interfaces.iter().find(|i| i.index != 1) {
+            let result = netlink.get_linktype_from_index(ethernet_iface.index).await;
+            assert!(result.is_ok());
+            let linktype = result.unwrap();
+            assert!(matches!(linktype, LinkType::Ethernet | LinkType::RawIP));
+        }
+
+        // [異常系] 存在しないインターフェースインデックス
+        let result = netlink.get_linktype_from_index(65535).await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            NetlinkError::NoSuchInterfaceIdx(_)
+        ));
+
+        Ok(())
+    }
 
     #[tokio::test]
     async fn test_get_route() -> Result<()> {
@@ -115,14 +176,56 @@ mod tests {
         let mut netlink = Netlink::new().await?;
 
         // ローカルホストへのルート取得をテスト
-        // let target_ip = Ipv4Addr::new(1, 1, 1, 1);
-        let target_ip = Ipv4Addr::new(10, 88, 0, 1);
-        // let target_ip = Ipv4Addr::new(127, 0, 0, 1);
+        let target_ip = Ipv4Addr::new(127, 0, 0, 1);
         let result = netlink.get_route(target_ip).await;
         assert!(result.is_ok());
         let route_entry = result.unwrap();
         assert_eq!(route_entry.to, IpAddr::V4(target_ip));
         assert!(!route_entry.interface.name.is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_parse_route_entry_from_route_msg() -> Result<()> {
+        let netlink = Netlink::new().await?;
+
+        // [正常系] 実際のインターフェースを使ったルートメッセージの解析テスト
+        let interfaces = netlink.get_interfaces()?;
+        if let Some(_test_interface) = interfaces.first() {
+            // RouteMessageを直接構築するのではなく、実際のネットワーク操作をテスト
+            let target_ip = Ipv4Addr::new(127, 0, 0, 1);
+            let mut test_netlink = Netlink::new().await?;
+            let route_result = test_netlink.get_route(target_ip).await;
+
+            // ルート取得が成功することを確認
+            assert!(route_result.is_ok());
+            let route_entry = route_result.unwrap();
+            assert_eq!(route_entry.to, IpAddr::V4(target_ip));
+            assert!(!route_entry.interface.name.is_empty());
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_execute_get_route_request() -> Result<()> {
+        // [正常系] RouteMessageが正常に作成されることを確認
+        let target_ip = Ipv4Addr::new(127, 0, 0, 1);
+        let builder = RouteMessageBuilder::<Ipv4Addr>::new();
+        let req_msg = builder
+            .destination_prefix(target_ip, 32)
+            .table_id(0)
+            .protocol(RouteProtocol::Unspec)
+            .scope(RouteScope::Universe)
+            .kind(RouteType::Unspec)
+            .build();
+
+        // メッセージが正常に構築されることを確認
+        assert_eq!(req_msg.header.destination_prefix_length, 32);
+        assert_eq!(req_msg.header.protocol, RouteProtocol::Unspec);
+        assert_eq!(req_msg.header.scope, RouteScope::Universe);
+        assert_eq!(req_msg.header.kind, RouteType::Unspec);
 
         Ok(())
     }


### PR DESCRIPTION
## 概要

Linux環境の対応

## 実装内容

- rtnetlinkを使用したLinux環境でのルーティング情報取得
- Linux環境でのループバック送信対応（自己返信機能）
- CI/CDでのLinux環境テスト実行有効化

## 動作確認

- [x] Linux環境での動作確認
- [x] macOS環境での動作確認
- [x] CIでの静的解析・テスト実行確認

## 関連Issue

Closes #24