### PR TITLE
ci 👷: git-cliffの最新バージョン動的取得への改善

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,8 +30,9 @@ jobs:
       - name: Install dependencies
         run: |
           # git-cliffのインストール
-          wget -qO- https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-0.24.2-x86_64-unknown-linux-gnu.tar.gz | tar -xzf -
-          sudo mv git-cliff-0.24.2/git-cliff /usr/local/bin/
+          GITCLIFF_VERSION=$(curl -s https://api.github.com/repos/orhun/git-cliff/releases/latest | jq -r '.tag_name')
+          wget -qO- "https://github.com/orhun/git-cliff/releases/download/${GITCLIFF_VERSION}/git-cliff-${GITCLIFF_VERSION#v}-x86_64-unknown-linux-gnu.tar.gz" | tar -xzf -
+          sudo mv "git-cliff-${GITCLIFF_VERSION#v}/git-cliff" /usr/local/bin/
 
       - name: Download PR body artifact
         uses: actions/download-artifact@v4
@@ -178,8 +179,9 @@ jobs:
           sudo apt-get install -y jq gh
 
           # git-cliffのインストール
-          wget -qO- https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-0.24.2-x86_64-unknown-linux-gnu.tar.gz | tar -xzf -
-          sudo mv git-cliff-0.24.2/git-cliff /usr/local/bin/
+          GITCLIFF_VERSION=$(curl -s https://api.github.com/repos/orhun/git-cliff/releases/latest | jq -r '.tag_name')
+          wget -qO- "https://github.com/orhun/git-cliff/releases/download/${GITCLIFF_VERSION}/git-cliff-${GITCLIFF_VERSION#v}-x86_64-unknown-linux-gnu.tar.gz" | tar -xzf -
+          sudo mv "git-cliff-${GITCLIFF_VERSION#v}/git-cliff" /usr/local/bin/
 
 
       - name: Create release artifacts


### PR DESCRIPTION
## 概要
git cliffのURL修正と常に最新版をダウンロードするように変更